### PR TITLE
Extra tests

### DIFF
--- a/benchmarks/no_select_ractor_test.rb
+++ b/benchmarks/no_select_ractor_test.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+
+require 'prime'
+require 'json'
+require 'digest/sha1'
+
+if ARGV.size != 3
+  STDERR.puts "Usage: ./no_select_ractor_test <num_workers> <num_requests> <outfile>"
+  exit 1
+end
+
+NUM_WORKERS = ARGV[0].to_i
+NUM_REQUESTS = ARGV[1].to_i
+OUTFILE = ARGV[2]
+
+t0 = Time.now
+
+pipe = Ractor.new do
+  loop do
+    Ractor.yield Ractor.recv
+  end
+end
+
+N = NUM_REQUESTS
+RN = NUM_WORKERS
+workers = (1..RN).map do
+  Ractor.new Ractor.current, pipe do |client, pipe|
+    while n = pipe.take
+      bools = (n..(n+99)).map { |nn| nn.prime? }
+      p_int = bools.inject(0) { |total, b| total * 2 + (b ? 1 : 0) }
+      client.send([n, p_int].freeze)
+    end
+  end
+end
+
+(1..(NUM_REQUESTS*NUM_WORKERS)).each{|i|
+  pipe << (i*100)
+}
+
+out = (1..(NUM_REQUESTS*NUM_WORKERS)).map {
+  Ractor.receive
+}
+t1 = Time.now
+working_time = t1 - t0
+
+out = out.sort_by {|pair| pair[0]}
+out_digest = Digest::SHA1.base64digest(out.inspect)
+
+out_data = {
+  type: 'ractor',
+  workers: NUM_WORKERS,
+  requests: NUM_REQUESTS,
+  time: working_time,
+  success: true,
+  digest: out_digest,
+}
+
+File.open(OUTFILE, "w") { |f| f.print(JSON.pretty_generate out_data); f.print("\n") }
+puts "Successfully wrote to #{OUTFILE} w/ Digest #{out_digest.inspect}..."

--- a/benchmarks/single_test.rb
+++ b/benchmarks/single_test.rb
@@ -1,0 +1,44 @@
+#!/usr/bin/env ruby
+
+require 'prime'
+require 'json'
+require 'digest/sha1'
+
+if ARGV.size != 3
+  STDERR.puts "Usage: ./single_test <num_workers> <num_requests> <outfile>"
+  exit 1
+end
+
+NUM_WORKERS = ARGV[0].to_i
+NUM_REQUESTS = ARGV[1].to_i
+OUTFILE = ARGV[2]
+
+t0 = Time.now
+
+N = NUM_REQUESTS
+RN = NUM_WORKERS
+
+out = (1..(NUM_REQUESTS*NUM_WORKERS)).map{|i|
+  n = (i*100)
+  bools = (n..(n+99)).map { |nn| nn.prime? }
+  p_int = bools.inject(0) { |total, b| total * 2 + (b ? 1 : 0) }
+  [n, p_int ]
+}
+
+t1 = Time.now
+working_time = t1 - t0
+
+out = out.sort_by {|pair| pair[0]}
+out_digest = Digest::SHA1.base64digest(out.inspect)
+
+out_data = {
+  type: 'ractor',
+  workers: NUM_WORKERS,
+  requests: NUM_REQUESTS,
+  time: working_time,
+  success: true,
+  digest: out_digest,
+}
+
+File.open(OUTFILE, "w") { |f| f.print(JSON.pretty_generate out_data); f.print("\n") }
+puts "Successfully wrote to #{OUTFILE} w/ Digest #{out_digest.inspect}..."


### PR DESCRIPTION
I found your post and tests very interesting 👍 

There's definitely an issue on Mac; performance is abysmal (like 10x slower on my 6-core Mac Pro)

I didn't get any crash though (using a very recent build `ruby 3.0.0dev (2020-11-26T00:37:38Z master af80df1820) [x86_64-darwin17]`)

I've read ko1 mention that `Ractor.select` wasn't very performant (and I think I understand why because I had the same issue when writing a backport for Ractor), so here's a test that avoids it altogether; maybe you'll get more encouraging results? I don't have the patience to test on another distro...

I thought adding a single thread comparison might be helpful too.